### PR TITLE
fix: enforce P2WSH multisig witness validation

### DIFF
--- a/lib/src/transaction/transaction_input.dart
+++ b/lib/src/transaction/transaction_input.dart
@@ -198,57 +198,53 @@ class TransactionInput {
 
       return Ecc.verifyEcdsa(sigHash, pub, rawSignature);
     } else if (utxo.scriptPubKey.isP2wsh()) {
-      String script = witnessList.last;
-
-      String size =
-          Codec.encodeHex(Codec.encodeVariableInteger(script.length ~/ 2));
-      MultisignatureScript witnessScript =
-          MultisignatureScript.parse(size + script);
-
-      Uint8List scriptPubKeyHash = utxo.scriptPubKey.commands[1] as Uint8List;
-      Uint8List scriptHash = Hash.sha256fromByte(Codec.decodeHex(script));
-
-      if (scriptHash.length != scriptPubKeyHash.length) {
+      if (witnessList.length < 3 || witnessList.first.toUpperCase() != '00') {
         return false;
       }
-      for (int i = 0; i < scriptHash.length; i++) {
-        if (scriptHash[i] != scriptPubKeyHash[i]) {
-          return false;
-        }
+
+      final String script = witnessList.last;
+      final String size =
+          Codec.encodeHex(Codec.encodeVariableInteger(script.length ~/ 2));
+      final MultisignatureScript witnessScript =
+          MultisignatureScript.parse(size + script);
+
+      final Uint8List scriptPubKeyHash = utxo.scriptPubKey.commands[1] as Uint8List;
+      final Uint8List scriptHash = Hash.sha256fromByte(Codec.decodeHex(script));
+      if (Codec.encodeHex(scriptHash) != Codec.encodeHex(scriptPubKeyHash)) {
+        return false;
       }
 
-      List<Uint8List> signatures = [];
-
-      for (int i = 1; i < witnessList.length - 1; i++) {
-        signatures.add(Codec.decodeHex(witnessList[i]));
-      }
-
-      List<Uint8List> pubKeys = witnessScript.getPublicKeys();
-
-      int requiredSigs = witnessScript.getRequiredSignature();
+      final List<Uint8List> signatures = [
+        for (int i = 1; i < witnessList.length - 1; i++)
+          Codec.decodeHex(witnessList[i]),
+      ];
+      final List<Uint8List> pubKeys = witnessScript.getPublicKeys();
+      final int requiredSigs = witnessScript.getRequiredSignature();
 
       if (signatures.length != requiredSigs) {
         return false;
       }
 
-      int validSigs = 0;
-
-      for (Uint8List sig in signatures) {
+      int nextPubKeyIndex = 0;
+      for (final Uint8List sig in signatures) {
         late final Uint8List rawSignature;
         try {
           rawSignature = Converter.derToRawSignature(sig);
-        } on FormatException {
+        } catch (_) {
           return false;
         }
-        for (Uint8List pub in pubKeys) {
-          if (Ecc.verifyEcdsa(sigHash, pub, rawSignature)) {
-            validSigs += 1;
-            continue;
+
+        bool matched = false;
+        while (nextPubKeyIndex < pubKeys.length) {
+          final Uint8List pubKey = pubKeys[nextPubKeyIndex++];
+          if (Ecc.verifyEcdsa(sigHash, pubKey, rawSignature)) {
+            matched = true;
+            break;
           }
         }
-      }
-      if (validSigs != requiredSigs) {
-        return false;
+        if (!matched) {
+          return false;
+        }
       }
       return true;
     } else if (utxo.scriptPubKey.isP2tr()) {

--- a/test/unit_test/transaction/transaction_input_test.dart
+++ b/test/unit_test/transaction/transaction_input_test.dart
@@ -255,6 +255,37 @@ void main() {
             true);
       });
 
+      test('returns false when a p2wsh signature is duplicated', () {
+        final Psbt psbt = PsbtFixture.p2wshSigned();
+        final TransactionOutput utxo = psbt.inputs[0].witnessUtxo!;
+        final String witnessScript =
+            psbt.inputs[0].witnessScript!.rawSerialize();
+        final Uint8List sigHash = Codec.decodeHex(psbt.unsignedTransaction!
+            .getSigHash(0, utxo, AddressType.p2wsh,
+                witnessScript: witnessScript));
+        final Transaction signedTx =
+            psbt.getSignedTransaction(AddressType.p2wsh);
+        final input = signedTx.inputs[0];
+        input.witnessList[2] = input.witnessList[1];
+
+        expect(input.verifySpend(sigHash, utxo), false);
+      });
+
+      test('returns false when a p2wsh dummy witness item is non-empty', () {
+        final Psbt psbt = PsbtFixture.p2wshSigned();
+        final TransactionOutput utxo = psbt.inputs[0].witnessUtxo!;
+        final String witnessScript =
+            psbt.inputs[0].witnessScript!.rawSerialize();
+        final Uint8List sigHash = Codec.decodeHex(psbt.unsignedTransaction!
+            .getSigHash(0, utxo, AddressType.p2wsh,
+                witnessScript: witnessScript));
+        final Transaction signedTx =
+            psbt.getSignedTransaction(AddressType.p2wsh);
+        signedTx.inputs[0].witnessList[0] = '01';
+
+        expect(signedTx.inputs[0].verifySpend(sigHash, utxo), false);
+      });
+
       test('returns false on malformed p2wsh DER signatures', () {
         final Psbt psbt = PsbtFixture.p2wshSigned();
         final TransactionOutput utxo = psbt.inputs[0].witnessUtxo!;


### PR DESCRIPTION
## What
 
Strengthen validation of finalized P2WSH multisig transaction witnesses.
 
Previously, P2WSH witness validation counted valid signatures independently
against all public keys. This could allow the same valid signature to be
counted multiple times toward the multisig threshold.
 
This change:
 
- Rejects malformed P2WSH witness structures.
- Requires an empty `CHECKMULTISIG` dummy element.
- Verifies that the witnessScript matches the P2WSH script commitment.
- Enforces the required signature count.
- Validates DER-encoded ECDSA signatures.
- Matches signatures against public keys in `CHECKMULTISIG` order.
- Prevents duplicate signatures from satisfying the multisig threshold.
 
## Why
 
A finalized multisig transaction must be validated based on the actual
witness contents, not only on the number of witness elements or signatures.
 
This prevents malformed witnesses, script commitment mismatches, and repeated
signatures from being accepted as valid P2WSH multisig spends.
 
## Tests
 
Added regression tests covering:
 
- Rejection of duplicated signatures.
- Rejection of non-empty `CHECKMULTISIG` dummy elements.
 
Validation performed:
 
- `dart analyze`
- `dart test`
 
All coconut_lib tests pass.
 
## Checklist
 
- [x] I reviewed the contributor guide and applied the relevant parts to this PR.